### PR TITLE
Fixing markdowndocs to pass linter

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: cloudposse/build-harness@0.39.0
+      - uses: cloudposse/build-harness@0.44.1
         with:
           entrypoint: /usr/bin/make
           args: readme/lint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -30,3 +30,4 @@ jobs:
         env:
           VALIDATE_ALL_CODEBASE: false
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VALIDATE_GO: false

--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ Available targets:
 
 ```
 <!-- markdownlint-restore -->
+<!-- markdownlint-disable -->
 ## Requirements
 
 | Name | Version |
@@ -180,6 +181,7 @@ Available targets:
 | service\_account\_role\_name | IAM role name |
 | service\_account\_role\_unique\_id | IAM role unique ID |
 
+<!-- markdownlint-restore -->
 
 
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable -->
 ## Requirements
 
 | Name | Version |
@@ -44,3 +45,4 @@
 | service\_account\_role\_name | IAM role name |
 | service\_account\_role\_unique\_id | IAM role unique ID |
 
+<!-- markdownlint-restore -->

--- a/test/src/examples_complete_test.go
+++ b/test/src/examples_complete_test.go
@@ -61,7 +61,7 @@ func TestExamplesComplete(t *testing.T) {
 
   rand.Seed(time.Now().UnixNano())
 
-  randId := strconv.Itoa(rand.Intn(1000))
+  randId := strconv.Itoa(rand.Intn(100000))
   attributes := []string{randId}
 
   terraformOptions := &terraform.Options{

--- a/test/src/examples_complete_test.go
+++ b/test/src/examples_complete_test.go
@@ -61,7 +61,7 @@ func TestExamplesComplete(t *testing.T) {
 
   rand.Seed(time.Now().UnixNano())
 
-  randId := strconv.Itoa(rand.Intn(10000))
+  randId := strconv.Itoa(rand.Intn(1000))
   attributes := []string{randId}
 
   terraformOptions := &terraform.Options{

--- a/test/src/examples_complete_test.go
+++ b/test/src/examples_complete_test.go
@@ -61,7 +61,7 @@ func TestExamplesComplete(t *testing.T) {
 
   rand.Seed(time.Now().UnixNano())
 
-  randId := strconv.Itoa(rand.Intn(100000))
+  randId := strconv.Itoa(rand.Intn(10000))
   attributes := []string{randId}
 
   terraformOptions := &terraform.Options{


### PR DESCRIPTION
## what
*  Docs generated with PRed changes to build harness

## why
* To pass linter

## references
* https://github.com/cloudposse/build-harness/pull/244
