### PR TITLE
Fixes examples source URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Here's how to invoke this example module in your projects
 
 ```hcl
 module "eks_iam_role" {
-  source = "https://github.com/cloudposse/terraform-aws-eks-iam-role.git?ref=master"
+  source = "git::https://github.com/cloudposse/terraform-aws-eks-iam-role.git?ref=master"
 
   namespace   = var.namespace
   environment = var.environment

--- a/README.yaml
+++ b/README.yaml
@@ -70,7 +70,7 @@ usage: |-
 
   ```hcl
   module "eks_iam_role" {
-    source = "https://github.com/cloudposse/terraform-aws-eks-iam-role.git?ref=master"
+    source = "git::https://github.com/cloudposse/terraform-aws-eks-iam-role.git?ref=master"
 
     namespace   = var.namespace
     environment = var.environment


### PR DESCRIPTION
## what
* Small update to README to use `git::` in front of repo URL. 

## why
* Better Copy pasta of the example


