### PR TITLE
feat: enables the ability to scope IAM roles to namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ Available targets:
 | name | Solution name, e.g. 'app' or 'jenkins' | `string` | `null` | no |
 | namespace | Namespace, which could be your organization name or abbreviation, e.g. 'eg' or 'cp' | `string` | `null` | no |
 | regex\_replace\_chars | Regex to replace chars with empty string in `namespace`, `environment`, `stage` and `name`.<br>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
+| scope\_role\_to\_namespace\_enabled | Enables scoping the created role to the namespace instead of an individual service account. | `bool` | `false` | no |
 | service\_account\_name | Kubernetes ServiceAccount name | `string` | n/a | yes |
 | service\_account\_namespace | Kubernetes Namespace where service account is deployed | `string` | n/a | yes |
 | stage | Stage, e.g. 'prod', 'staging', 'dev', OR 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -32,6 +32,7 @@
 | name | Solution name, e.g. 'app' or 'jenkins' | `string` | `null` | no |
 | namespace | Namespace, which could be your organization name or abbreviation, e.g. 'eg' or 'cp' | `string` | `null` | no |
 | regex\_replace\_chars | Regex to replace chars with empty string in `namespace`, `environment`, `stage` and `name`.<br>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
+| scope\_role\_to\_namespace\_enabled | Enables scoping the created role to the namespace instead of an individual service account. | `bool` | `false` | no |
 | service\_account\_name | Kubernetes ServiceAccount name | `string` | n/a | yes |
 | service\_account\_namespace | Kubernetes Namespace where service account is deployed | `string` | n/a | yes |
 | stage | Stage, e.g. 'prod', 'staging', 'dev', OR 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |

--- a/variables.tf
+++ b/variables.tf
@@ -28,3 +28,9 @@ variable "eks_cluster_oidc_issuer_url" {
   type        = string
   description = "OIDC issuer URL for the EKS cluster (initial \"https://\" may be omitted)"
 }
+
+variable "scope_role_to_namespace_enabled" {
+  default     = false
+  type        = bool
+  description = "Enables scoping the created role to the namespace instead of an individual service account."
+}


### PR DESCRIPTION
## what
* Adds `var.scope_role_to_namespace_enabled` 

## why
* Provides the ability to scope the created IAM role to the namespace instead of the individual service account. 

## references
* See AWS docs for more information: https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts-technical-overview.html#iam-role-configuration:~:text=To%20scope%20a%20role%20to%20an%20entire%20namespace%20(to%20use%20the%20namespace%20as%20a%20boundary)%3A

