### PR TITLE
Fix broken link to examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ data "aws_iam_policy_document" "autoscaler" {
 ## Examples
 
 Here is an example of using this module:
-- [`examples/complete`](https://github.com/cloudposse/terraform-aws-eks-iam-role/examples/complete) - complete example of using this module
+- [`examples/complete`](https://github.com/cloudposse/terraform-aws-eks-iam-role/tree/master/examples/complete) - complete example of using this module
 
 
 

--- a/README.yaml
+++ b/README.yaml
@@ -116,7 +116,7 @@ usage: |-
 # Example usage
 examples: |-
   Here is an example of using this module:
-  - [`examples/complete`](https://github.com/cloudposse/terraform-aws-eks-iam-role/examples/complete) - complete example of using this module
+  - [`examples/complete`](https://github.com/cloudposse/terraform-aws-eks-iam-role/tree/master/examples/complete) - complete example of using this module
 
 # How to get started quickly
 #quickstart: |-


### PR DESCRIPTION
## What

Fix the broken link to examples by using the link to the examples of the `master` branch.

## Why
* Link to examples was not working.

