### PR TITLE
Add validation to oidc issuer url

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,7 +336,7 @@ In general, PRs are welcome. We follow the typical "fork-and-pull" Git workflow.
 
 ## Copyrights
 
-Copyright © 2020-2021 [Cloud Posse, LLC](https://cloudposse.com)
+Copyright © 2020-2022 [Cloud Posse, LLC](https://cloudposse.com)
 
 
 

--- a/variables.tf
+++ b/variables.tf
@@ -34,4 +34,9 @@ variable "aws_iam_policy_document" {
 variable "eks_cluster_oidc_issuer_url" {
   type        = string
   description = "OIDC issuer URL for the EKS cluster (initial \"https://\" may be omitted)"
+
+  validation {
+    condition     = length(var.eks_cluster_oidc_issuer_url) > 0
+    error_message = "The eks_cluster_oidc_issuer_url value must have a value"
+  }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -37,6 +37,6 @@ variable "eks_cluster_oidc_issuer_url" {
 
   validation {
     condition     = length(var.eks_cluster_oidc_issuer_url) > 0
-    error_message = "The eks_cluster_oidc_issuer_url value must have a value"
+    error_message = "The eks_cluster_oidc_issuer_url value must have a value."
   }
 }


### PR DESCRIPTION
## what
* Add validation to oidc issuer url

## why
* Make sure the value of the eks oidc issuer url is non null. This prevents creation of an unadsumable eks iam role.

## references
* https://github.com/cloudposse/terraform-aws-helm-release is affected if the iam role is enabled but the eks oidc url is left with the default null value
* https://github.com/cloudposse/terraform-aws-eks-iam-role/pull/25