### PR TITLE
oidc eks null check

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -53,7 +53,7 @@ module "cert-manager_role" {
   aws_account_number = data.aws_caller_identity.current.account_id
   # Rather than create a whole cluster, just fake the OIDC URL
   # eks_cluster_oidc_issuer_url = module.eks_cluster.eks_cluster_identity_oidc_issuer
-  eks_cluster_oidc_issuer_url = "https://oidc.eks.us-west-2.amazonaws.com/id/FEDCBA9876543210FEDCBA9876543210"
+  eks_cluster_oidc_issuer_url = null
   aws_iam_policy_document     = [data.aws_iam_policy_document.cert-manager.json]
 
   context = module.this.context


### PR DESCRIPTION
Just a test to make sure terraform doesnt panic and simply fails on the validation check

The length check seems to work correctly on the oidc validation