### PR TITLE
Refactor enable logic to use counts instead of `for_each`

### DIFF
--- a/.github/auto-release.yml
+++ b/.github/auto-release.yml
@@ -47,7 +47,7 @@ template: |
 
 replacers:
 # Remove irrelevant information from Renovate bot
-- search: '/(?<=---\s+)+^#.*(Renovate configuration|Configuration)(?:.|\n)*?This PR has been generated .*/gm'
+- search: '/(?<=---\s)\s*^#.*(Renovate configuration|Configuration)(?:.|\n)*?This PR has been generated .*/gm'
   replace: ''
 # Remove Renovate bot banner image
 - search: '/\[!\[[^\]]*Renovate\][^\]]*\](\([^)]*\))?\s*\n+/gm'

--- a/.github/workflows/auto-context.yml
+++ b/.github/workflows/auto-context.yml
@@ -35,7 +35,7 @@ jobs:
 
     - name: Create Pull Request
       if: steps.update.outputs.create_pull_request == 'true'
-      uses: cloudposse/actions/github/create-pull-request@0.22.0
+      uses: cloudposse/actions/github/create-pull-request@0.30.0
       with:
         token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
         committer: 'cloudpossebot <11232728+cloudpossebot@users.noreply.github.com>'

--- a/.github/workflows/auto-format.yml
+++ b/.github/workflows/auto-format.yml
@@ -62,7 +62,7 @@ jobs:
         fi
 
     - name: Auto Test
-      uses: cloudposse/actions/github/repository-dispatch@0.22.0
+      uses: cloudposse/actions/github/repository-dispatch@0.30.0
       # match users by ID because logins (user names) are inconsistent,
       # for example in the REST API Renovate Bot is `renovate[bot]` but
       # in GraphQL it is just `renovate`, plus there is a non-bot

--- a/.github/workflows/auto-readme.yml
+++ b/.github/workflows/auto-readme.yml
@@ -1,0 +1,71 @@
+name: "auto-readme"
+on:
+  workflow_dispatch:
+
+  schedule:
+  # Example of job definition:
+  # .---------------- minute (0 - 59)
+  # |  .------------- hour (0 - 23)
+  # |  |  .---------- day of month (1 - 31)
+  # |  |  |  .------- month (1 - 12) OR jan,feb,mar,apr ...
+  # |  |  |  |  .---- day of week (0 - 6) (Sunday=0 or 7) OR sun,mon,tue,wed,thu,fri,sat
+  # |  |  |  |  |
+  # *  *  *  *  * user-name command to be executed
+
+  # Update README.md nightly at 4am UTC
+  - cron:  '0 4 * * *'
+
+jobs:
+  update:
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Find default branch name
+      id: defaultBranch
+      shell: bash
+      env:
+        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+      run: |
+        default_branch=$(gh repo view --json defaultBranchRef --jq .defaultBranchRef.name)
+        printf "::set-output name=defaultBranch::%s\n" "${default_branch}"
+        printf "defaultBranchRef.name=%s\n" "${default_branch}"
+
+    - name: Update readme
+      shell: bash
+      id: update
+      env:
+        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        DEF: "${{ steps.defaultBranch.outputs.defaultBranch }}"
+      run: |
+        make init
+        make readme/build
+        # Ignore changes if they are only whitespace
+        if ! git diff --quiet README.md && git diff --ignore-all-space --ignore-blank-lines --quiet README.md; then
+          git restore README.md
+          echo Ignoring whitespace-only changes in README
+        fi
+
+    - name: Create Pull Request
+      # This action will not create or change a pull request if there are no changes to make.
+      # If a PR of the auto-update/readme branch is open, this action will just update it, not create a new PR.
+      uses: cloudposse/actions/github/create-pull-request@0.30.0
+      with:
+        token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
+        commit-message: Update README.md and docs
+        title: Update README.md and docs
+        body: |-
+          ## what
+          This is an auto-generated PR that updates the README.md and docs
+
+          ## why
+          To have most recent changes of README.md and doc from origin templates
+
+        branch: auto-update/readme
+        base: ${{ steps.defaultBranch.outputs.defaultBranch }}
+        delete-branch: true
+        labels: |
+          auto-update
+          no-release
+          readme

--- a/.github/workflows/chatops.yml
+++ b/.github/workflows/chatops.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: "Handle common commands"
-        uses: cloudposse/actions/github/slash-command-dispatch@0.22.0
+        uses: cloudposse/actions/github/slash-command-dispatch@0.30.0
         with:
           token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
           reaction-token: ${{ secrets.GITHUB_TOKEN }}
@@ -24,7 +24,7 @@ jobs:
       - name: "Checkout commit"
         uses: actions/checkout@v2
       - name: "Run tests"
-        uses: cloudposse/actions/github/slash-command-dispatch@0.22.0
+        uses: cloudposse/actions/github/slash-command-dispatch@0.30.0
         with:
           token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
           reaction-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/validate-codeowners.yml
+++ b/.github/workflows/validate-codeowners.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
     - name: "Checkout source code at current commit"
       uses: actions/checkout@v2
-    - uses: mszostok/codeowners-validator@v0.5.0
+    - uses: mszostok/codeowners-validator@v0.7.1
       if: github.event.pull_request.head.repo.full_name == github.repository
       name: "Full check of CODEOWNERS"
       with:
@@ -18,10 +18,12 @@ jobs:
         # files so we can use the same CODEOWNERS file for Terraform and non-Terraform repos
         #   checks: "files,syntax,owners,duppatterns"
         checks: "syntax,owners,duppatterns"
+        owner_checker_allow_unowned_patterns: "false"
         # GitHub access token is required only if the `owners` check is enabled
         github_access_token: "${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}"
-    - uses: mszostok/codeowners-validator@v0.5.0
+    - uses: mszostok/codeowners-validator@v0.7.1
       if: github.event.pull_request.head.repo.full_name != github.repository
       name: "Syntax check of CODEOWNERS"
       with:
         checks: "syntax,duppatterns"
+        owner_checker_allow_unowned_patterns: "false"

--- a/main.tf
+++ b/main.tf
@@ -82,7 +82,7 @@ data "aws_iam_policy_document" "service_account_assume_role" {
 }
 
 resource "aws_iam_policy" "service_account" {
-  count       = local.iam_policy_enabled > 0 ? 1 : 0
+  count       = local.iam_policy_enabled ? 1 : 0
   name        = module.service_account_label.id
   description = format("Grant permissions to EKS ServiceAccount %s", local.service_account_id)
   policy      = local.aws_iam_policy_document
@@ -90,7 +90,7 @@ resource "aws_iam_policy" "service_account" {
 }
 
 resource "aws_iam_role_policy_attachment" "service_account" {
-  count      = local.iam_policy_enabled > 0 ? 1 : 0
+  count      = local.iam_policy_enabled ? 1 : 0
   role       = aws_iam_role.service_account[0].name
   policy_arn = aws_iam_policy.service_account[0].arn
 }

--- a/main.tf
+++ b/main.tf
@@ -82,7 +82,7 @@ data "aws_iam_policy_document" "service_account_assume_role" {
 }
 
 resource "aws_iam_policy" "service_account" {
-  count       = local.iam_policy_enabled > 0 ? 1 :0
+  count       = local.iam_policy_enabled > 0 ? 1 : 0
   name        = module.service_account_label.id
   description = format("Grant permissions to EKS ServiceAccount %s", local.service_account_id)
   policy      = local.aws_iam_policy_document

--- a/outputs.tf
+++ b/outputs.tf
@@ -9,31 +9,31 @@ output "service_account_name" {
 }
 
 output "service_account_role_name" {
-  value       = local.enabled ? values(aws_iam_role.service_account)[0].name : null
+  value       = local.enabled ? aws_iam_role.service_account[0].name : null
   description = "IAM role name"
 }
 
 output "service_account_role_unique_id" {
-  value       = local.enabled ? values(aws_iam_role.service_account)[0].unique_id : null
+  value       = local.enabled ? aws_iam_role.service_account[0].unique_id : null
   description = "IAM role unique ID"
 }
 
 output "service_account_role_arn" {
-  value       = local.enabled ? values(aws_iam_role.service_account)[0].arn : null
+  value       = local.enabled ? aws_iam_role.service_account[0].arn : null
   description = "IAM role ARN"
 }
 
 output "service_account_policy_name" {
-  value       = local.enabled && length(var.aws_iam_policy_document) > 0 ? values(aws_iam_policy.service_account)[0].name : null
+  value       = local.aws_policy_enabled ? aws_iam_policy.service_account[0].name : null
   description = "IAM policy name"
 }
 
 output "service_account_policy_id" {
-  value       = local.enabled && length(var.aws_iam_policy_document) > 0 ? values(aws_iam_policy.service_account)[0].id : null
+  value       = local.aws_policy_enabled ? aws_iam_policy.service_account[0].id : null
   description = "IAM policy ID"
 }
 
 output "service_account_policy_arn" {
-  value       = local.enabled && length(var.aws_iam_policy_document) > 0 ? values(aws_iam_policy.service_account)[0].arn : null
+  value       = local.aws_policy_enabled ? aws_iam_policy.service_account[0].arn : null
   description = "IAM policy ARN"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -24,16 +24,16 @@ output "service_account_role_arn" {
 }
 
 output "service_account_policy_name" {
-  value       = local.aws_policy_enabled ? aws_iam_policy.service_account[0].name : null
+  value       = local.iam_policy_enabled ? aws_iam_policy.service_account[0].name : null
   description = "IAM policy name"
 }
 
 output "service_account_policy_id" {
-  value       = local.aws_policy_enabled ? aws_iam_policy.service_account[0].id : null
+  value       = local.iam_policy_enabled ? aws_iam_policy.service_account[0].id : null
   description = "IAM policy ID"
 }
 
 output "service_account_policy_arn" {
-  value       = local.aws_policy_enabled ? aws_iam_policy.service_account[0].arn : null
+  value       = local.iam_policy_enabled ? aws_iam_policy.service_account[0].arn : null
   description = "IAM policy ARN"
 }


### PR DESCRIPTION
## what
Use `count` instead of `for_each` to manage if a resource is enabled or disabled.

## why

If any element of the service account name is not known at plan time, `for_each` would cause the plan to fail. 

The main advantage of `for_each` over `count` is stability when an item in a list is added or removed or the order of elements in a list changes. With `for_each`, only the changed item is affected, while with `count` other items can be affected by being moved to a different position in the list. This advantage is not applicable to this module because there is always only one item.

## note

This change will cause the IAM role to be deleted and recreated. If you have attached policies to the role outside of this module, you will need to reattach them.
