### PR TITLE
Do not validate inputs when disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,10 +89,6 @@ We highly recommend that in your code you pin the version to the exact version y
 using so that your infrastructure remains stable, and update versions in a
 systematic way so that they do not catch you by surprise.
 
-Also, because of a bug in the Terraform registry ([hashicorp/terraform#21417](https://github.com/hashicorp/terraform/issues/21417)),
-the registry shows many of our inputs as required when in fact they are optional.
-The table below correctly indicates which inputs are required.
-
 
 Here's how to invoke this module in your projects
 
@@ -167,7 +163,7 @@ Available targets:
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | >= 1.2 |
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -3,7 +3,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | >= 1.2 |
 

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0.0"
+  required_version = ">= 1.2.0"
 
   required_providers {
     aws = {

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,7 @@
 locals {
   enabled = module.this.enabled
 
-  eks_cluster_oidc_issuer = replace(var.eks_cluster_oidc_issuer_url, "https://", "")
+  eks_cluster_oidc_issuer = local.enabled ? replace(var.eks_cluster_oidc_issuer_url, "https://", "") : ""
 
   aws_account_number = local.enabled ? coalesce(var.aws_account_number, data.aws_caller_identity.current[0].account_id) : ""
 
@@ -93,6 +93,13 @@ data "aws_iam_policy_document" "service_account_assume_role" {
       test     = "StringEquals"
       values   = ["sts.amazonaws.com"]
       variable = format("%s:aud", local.eks_cluster_oidc_issuer)
+    }
+  }
+
+  lifecycle {
+    precondition {
+      condition     = length(local.eks_cluster_oidc_issuer) > 0
+      error_message = "The eks_cluster_oidc_issuer_url value must have a value."
     }
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -50,11 +50,6 @@ variable "aws_iam_policy_document" {
 variable "eks_cluster_oidc_issuer_url" {
   type        = string
   description = "OIDC issuer URL for the EKS cluster (initial \"https://\" may be omitted)"
-
-  validation {
-    condition     = length(var.eks_cluster_oidc_issuer_url) > 0
-    error_message = "The eks_cluster_oidc_issuer_url value must have a value."
-  }
 }
 
 variable "permissions_boundary" {

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0.0"
+  required_version = ">= 1.2.0"
 
   required_providers {
     aws = {


### PR DESCRIPTION
## what

- Replace variable validations with precondition

## why

- Variable validation cannot take other variables into account. With precondition, we can allow invalid inputs when the module is disabled.

## references

- Supersedes and closes #35 
