### PR TITLE
feat: attachement of the managed policies fixes cloudposse/terraform-aws-eks-iam-role#41

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -117,3 +117,9 @@ resource "aws_iam_role_policy_attachment" "service_account" {
   role       = aws_iam_role.service_account[0].name
   policy_arn = aws_iam_policy.service_account[0].arn
 }
+
+resource "aws_iam_role_policy_attachment" "managed" {
+  for_each   = module.this.enabled ? var.managed_policy_arns : []
+  role       = aws_iam_role.service_account[0].name
+  policy_arn = each.key
+}

--- a/variables.tf
+++ b/variables.tf
@@ -47,6 +47,12 @@ variable "aws_iam_policy_document" {
     EOT
 }
 
+variable "managed_policy_arns" {
+  type        = set(string)
+  description = "List of managed policies to attach to created role"
+  default     = []
+}
+
 variable "eks_cluster_oidc_issuer_url" {
   type        = string
   description = "OIDC issuer URL for the EKS cluster (initial \"https://\" may be omitted)"


### PR DESCRIPTION
## what

Possibility to attach managed policies like in https://github.com/cloudposse/terraform-aws-iam-role

## why

* Be consistent with the existing modules
* Avoid boilerplate code to attach a managed policy via data resource

## references

closes cloudposse/terraform-aws-eks-iam-role#41
