### PR TITLE
docs: fix ARN typo

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -6,21 +6,21 @@ locals {
   aws_account_number = local.enabled ? coalesce(var.aws_account_number, data.aws_caller_identity.current[0].account_id) : ""
 
   # If both var.service_account_namespace and var.service_account_name are provided,
-  # then the role ARM will have one of the following formats:
+  # then the role ARN will have one of the following formats:
   # 1. if var.service_account_namespace != var.service_account_name: arn:aws:iam::<account_number>:role/<namespace>-<environment>-<stage>-<optional_name>-<service_account_name>@<service_account_namespace>
   # 2. if var.service_account_namespace == var.service_account_name: arn:aws:iam::<account_number>:role/<namespace>-<environment>-<stage>-<optional_name>-<service_account_name>
 
   # 3. If var.service_account_namespace == "" and var.service_account_name is provided,
-  # then the role ARM will have format arn:aws:iam::<account_number>:role/<namespace>-<environment>-<stage>-<optional_name>-<service_account_name>@all,
+  # then the role ARN will have format arn:aws:iam::<account_number>:role/<namespace>-<environment>-<stage>-<optional_name>-<service_account_name>@all,
   # and the policy will use a wildcard for the namespace in the test condition to allow ServiceAccounts in any Kubernetes namespace to assume the role (useful for unlimited preview environments)
 
   # 4. If var.service_account_name == "" and var.service_account_namespace is provided,
-  # then the role ARM will have format arn:aws:iam::<account_number>:role/<namespace>-<environment>-<stage>-<optional_name>-all@<service_account_namespace>,
+  # then the role ARN will have format arn:aws:iam::<account_number>:role/<namespace>-<environment>-<stage>-<optional_name>-all@<service_account_namespace>,
   # and the policy will use a wildcard for the service account name in the test condition to allow any ServiceAccount in the given namespace to assume the role.
   # For more details, see https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts-technical-overview.html#iam-role-configuration
 
   # 5. If both var.service_account_name == "" and var.service_account_namespace == "",
-  # then the role ARM will have format arn:aws:iam::<account_number>:role/<namespace>-<environment>-<stage>-<optional_name>-all@all,
+  # then the role ARN will have format arn:aws:iam::<account_number>:role/<namespace>-<environment>-<stage>-<optional_name>-all@all,
   # and the policy will use wildcards for both the namespace and the service account name in the test condition to allow all ServiceAccounts
   # in all Kubernetes namespaces to assume the IAM role (not recommended).
 


### PR DESCRIPTION
## what

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->
fixes a few typos in the comments: `ARM` -> `ARN`
